### PR TITLE
Forward Geocode

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -19,8 +19,10 @@ class App extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      lat: 0,
-      long: 0,
+      clientLat: 0,
+      clientLong: 0,
+      mapLat: 0,
+      mapLong: 0,
       loading: true,
       restaurants: [],
       searchbox: '',
@@ -42,7 +44,7 @@ class App extends Component {
   */
   getYelpData = async () => {
     if(!this.state.loading) {
-      const response = await axios.get(`http://localhost:3090/yelp/?latitude=${this.state.lat}&longitude=${this.state.long}&searchbox=${this.state.searchbox}`);
+      const response = await axios.get(`http://localhost:3090/yelp/?latitude=${this.state.mapLat}&longitude=${this.state.mapLong}&searchbox=${this.state.searchbox}`);
       console.log("This is the response from the GET /yelp api call ", response);
       this.setState({ restaurants: response.data });
     }
@@ -54,8 +56,8 @@ class App extends Component {
     { lat: Number, lng: Number }
   */
   returnCenter = () => {
-    const lat = this.state.lat;
-    const long = this.state.long;
+    const lat = this.state.mapLat;
+    const long = this.state.mapLong;
     const center = {};
     center["lat"] = lat;
     center["lng"] = long;
@@ -65,7 +67,12 @@ class App extends Component {
   // Why: I use ip-api.com because the window.geolocation was not reliable
   getLocation = async () => {
     const response = await axios.get("http://ip-api.com/json");
-    this.setState({ lat: response.data.lat, long: response.data.lon, loading: false })
+    this.setState({ clientLat: response.data.lat, 
+                    clientLong: response.data.lon, 
+                    mapLat: response.data.lat,
+                    mapLong: response.data.lon,
+                    loading: false 
+                  });
   }
 
   // handleChange & handleSubmit are used in the searchbar feature of NavBar component
@@ -79,10 +86,10 @@ class App extends Component {
 
 
   forwardGeocode = async () => {
-    const { lat, long, searchLocation } = this.state;
-    const response = await axios.get(`http://localhost:3090/forwardgeocode/?lat=${lat}&lng=${long}&location=${searchLocation}`);
+    const { clientLat, clientLong, searchLocation } = this.state;
+    const response = await axios.get(`http://localhost:3090/forwardgeocode/?lat=${clientLat}&lng=${clientLong}&location=${searchLocation}`);
     console.log(response.data);
-    this.setState({ lat: response.data.lat, long: response.data.lng });
+    this.setState({ mapLat: response.data.lat, mapLong: response.data.lng });
   }
 
   handleSubmit = (e) => {

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -77,10 +77,21 @@ class App extends Component {
     this.setState({ searchLocation: e.target.value });
   }
 
+
+  forwardGeocode = async () => {
+    const { lat, long, searchLocation } = this.state;
+    const response = await axios.get(`http://localhost:3090/forwardgeocode/?lat=${lat}&lng=${long}&location=${searchLocation}`);
+    console.log(response.data);
+    this.setState({ lat: response.data.lat, long: response.data.lng });
+  }
+
   handleSubmit = (e) => {
     e.preventDefault();
     // getYelpData has access to the application state, and does not need to be passed any information.
-    this.getYelpData();
+    this.forwardGeocode().then(this.getYelpData);
+
+
+
   }
 
   // When I click on the list card

--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -84,7 +84,6 @@ class App extends Component {
     this.setState({ searchLocation: e.target.value });
   }
 
-
   forwardGeocode = async () => {
     const { clientLat, clientLong, searchLocation } = this.state;
     const response = await axios.get(`http://localhost:3090/forwardgeocode/?lat=${clientLat}&lng=${clientLong}&location=${searchLocation}`);
@@ -96,9 +95,6 @@ class App extends Component {
     e.preventDefault();
     // getYelpData has access to the application state, and does not need to be passed any information.
     this.forwardGeocode().then(this.getYelpData);
-
-
-
   }
 
   // When I click on the list card

--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -8,6 +8,7 @@ import "../styles/card.css";
         1. These classNames are not acceptable.
         2. Refine the desktop style
         3. Make this work on mobile devices
+        4. There may be times where there is no categories!!! Comment out for now, refactor during client side error handing.
 */
 
 const Card = (props) => {
@@ -20,7 +21,8 @@ const Card = (props) => {
                 <div className="info">
                     <span className="restaurant-title">{props.name}</span>
                     <span>{props.price}</span>
-                    <span>{props.categories[0].title}</span>
+
+                    {/* <span>{props.categories[0].title}</span> */}
                     <span>{props.address[0] + " " + props.address[1]}</span>
                     <span>{props.rating}</span>
                     <span>{props.phone}</span>

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -37,8 +37,10 @@ const NavBar = (props) => {
                         <input className="nav-search-button" type='submit' value="Go"></input>
                 </form>
                 {/* <Link to="/auth" className="signin" style={{textDecoration: 'none'}} >Sign in / Sign up</Link> */}
-                <Button className="nav-auth-button" text="Sign In" dest="/signin" />
-                <Button className="nav-auth-button-acc" text="Sign Up" dest="/auth" />
+                <div className="nav-auth-button-container">
+                    <Button className="nav-auth-button" text="Sign In" dest="/signin" />
+                    <Button className="nav-auth-button-acc" text="Sign Up" dest="/auth" />
+                </div>
             </div>
         </nav>
     );

--- a/client/src/components/NavBar.js
+++ b/client/src/components/NavBar.js
@@ -14,8 +14,8 @@ const NavBar = (props) => {
                     <Link to="/" style={{textDecoration: 'none'}}><Logo /></Link>
                     <form className="search-container" onSubmit={props.submit}>
                         <label className="search-label">
-                            <input className="nav-searchbar" type='text' value={props.value} onChange={props.change}></input>
-                            <input className="nav-searchbar" type='text' value={props.location} onChange={props.changeLocation}></input>
+                            <input className="nav-searchbar" type='text' value={props.value} onChange={props.change} placeholder="tacos, cheap dinner, Cafe Mogador"></input>
+                            <input className="nav-searchbar" type='text' value={props.location} onChange={props.changeLocation} placeholder="address, neighborhood, city, state, or zip"></input>
                         </label>
                             <input className="nav-search-button" type='submit' value="Go"></input>
                     </form>
@@ -31,8 +31,8 @@ const NavBar = (props) => {
                 <Link to="/" style={{textDecoration: 'none'}}><Logo /></Link>
                 <form className="search-container" onSubmit={props.submit}>
                     <label className="search-label">
-                        <input className="nav-searchbar" type='text' value={props.value} onChange={props.change}></input>
-                        <input className="nav-searchbar" type='text' value={props.location} onChange={props.changeLocation}></input>
+                        <input className="nav-searchbar" type='text' value={props.value} onChange={props.change} placeholder="tacos, cheap dinner, Cafe Mogador"></input>
+                        <input className="nav-searchbar" type='text' value={props.location} onChange={props.changeLocation} placeholder="address, neighborhood, city, state, or zip"></input>
                     </label>
                         <input className="nav-search-button" type='submit' value="Go"></input>
                 </form>

--- a/client/src/components/NewMap.js
+++ b/client/src/components/NewMap.js
@@ -22,39 +22,32 @@ const Marker = (props) => <div className={props.className} onClick={() => alert(
 class NewMap extends Component {
 
   static defaultProps = {
-    zoom: 14
+    zoom: 13
   };
 
   renderMap = () => {
-    console.log(this.props.center)
     if(this.props.loading) return null;
     return (
-    <GoogleMapReact
-          bootstrapURLKeys={{ key: key}}
-          center={this.props.center}
-          defaultZoom={this.props.zoom}
-        >
-          {
-            this.props.restaurants.map(rest => {
-              let currentStyle = "pin";
-              if(this.props.currentRestaurant === rest.id) {
-                console.log("This runs here!");
-                currentStyle = "pin-highlighted"
-              }
-              return <Marker lat={rest.coordinates.latitude} lng={rest.coordinates.longitude} text={rest.name}  className={currentStyle}/>
+      <GoogleMapReact
+        bootstrapURLKeys={{ key: key}}
+        center={this.props.center}
+        defaultZoom={this.props.zoom}
+      >
+        {
+          this.props.restaurants.map(rest => {
+            let currentStyle = "pin";
+            if(this.props.currentRestaurant === rest.id) {
+              currentStyle = "pin-highlighted"
             }
-            )
-          }<Marker
-            lat={this.props.center.lat}
-            lng={this.props.center.lng}
-            text="Robert Checco"
-          />
-    </GoogleMapReact> );
+            return <Marker lat={rest.coordinates.latitude} lng={rest.coordinates.longitude} text={rest.name}  className={currentStyle}/>
+          }
+          )
+        }
+      </GoogleMapReact> );
   }
 
   render() {
     return (
-      // Important! Always set the container height explicitly
       <div className="map-container">
         {this.renderMap()}
       </div>

--- a/client/src/components/NewMap.js
+++ b/client/src/components/NewMap.js
@@ -22,15 +22,16 @@ const Marker = (props) => <div className={props.className} onClick={() => alert(
 class NewMap extends Component {
 
   static defaultProps = {
-    zoom: 12
+    zoom: 14
   };
 
   renderMap = () => {
+    console.log(this.props.center)
     if(this.props.loading) return null;
     return (
     <GoogleMapReact
           bootstrapURLKeys={{ key: key}}
-          defaultCenter={this.props.center}
+          center={this.props.center}
           defaultZoom={this.props.zoom}
         >
           {

--- a/client/src/styles/map.css
+++ b/client/src/styles/map.css
@@ -1,8 +1,4 @@
-/* .map-container {
-    flex-grow: 3;
-    height: 90vh;
-} */
-
+/* Important! Always set the container height explicitly */
 .map-container {
   height: calc(100vh - 100px);
   width: 75%;

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -65,10 +65,16 @@
 .nav-auth-button {
     font-family: sans-serif;
     color: white;
+    margin-right: 25px;
 }
 
 .nav-auth-button-acc {
     background-color: #3AAFA9;
     color: white;
     font-family: sans-serif;
+}
+
+.nav-auth-button-container {
+    display: flex;
+    flex-direction: row;
 }

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -36,8 +36,9 @@
 }
 
 .nav-searchbar {
+    box-sizing: border-box;
     border: none;
-    padding: 0;
+    padding: 5px 0px 5px 15px;
     border-left: 1px solid gray;
     height: 100%;
     width: 80%;

--- a/client/src/styles/navbar.css
+++ b/client/src/styles/navbar.css
@@ -47,6 +47,7 @@
 .search-label {
     display: flex;
     flex-direction: row;
+    width: 100%;
 }
 
 .nav-search-button {

--- a/server/router.js
+++ b/server/router.js
@@ -1,10 +1,21 @@
 const axios = require('axios');
 const cors = require('cors');
-const { yelp } = require('./config/keys');
+const { yelp, openCage } = require('./config/keys');
 const User = require('./models/User');
 const auth = require('./middleware/auth');
 
 module.exports = function (app) {
+
+    app.get('/forwardgeocode', async (req, res) => {
+        console.log("This runs here line 10!");
+        const { location, lat, lng } = req.query;
+        try {
+            const response = await axios.get(`https://api.opencagedata.com/geocode/v1/json?q=${location}&proximity=${lat},${lng}&key=${openCage}`);
+            res.send(response.data.results[0].geometry);
+        } catch(e) {
+            res.status(500).send();
+        }
+    });
 
     app.get('/yelp', async(req, res) => {
         let lat = req.query.latitude;
@@ -38,18 +49,6 @@ module.exports = function (app) {
         const response = await axios.get(`https://api.yelp.com/v3/businesses/${req.params.id}`, options);
         res.send(response.data);
     });
-
-    // Forward for forward geocoding. The process of providing a string and receiving the gps information of a location
-    // @ params from req.body
-    // app.get('/forward', async(req, res) => {
-    //     const { lat, lng, location } = req.body;
-    //     const response = await axios.get(`https://api.opencagedata.com/geocode/v1/json?q=${location}&proximity=${lat},${lng}&key=${openCage}`);
-    //     const returnMe = [];
-    //     for(let i = 0; i < response.data.results.length; i++) {
-    //         returnMe.push(response.data.results[i].formatted);
-    //     }
-    //     res.send(returnMe);
-    // })
 
     /* Routes for user requests */
 
@@ -90,5 +89,5 @@ module.exports = function (app) {
         } catch (e) {
             res.status(500).send();
         }
-    })
+    });
 }


### PR DESCRIPTION
Forward Geocoding is the process of transforming a human readable (such as Mountain View, CA) string into latitude and longitude coordinates. With the help of opencagedata api, the application's GET /forwardgeocode api supports forward geocoding on the server-side. However, this is a greedy approach because there are duplicate named cities/locations. For example, a user search of "springfield" may be looking for Springfield, MA || Springfield, IL || other. My solution was to store the client's latitude and longitude in state and pass this to the GET /forwardgeocode api. Within the /forwardgeocode api I pass the client's location in the query string to opencagedata api under the "proximity" parameter. I select the location that is the highest ranked in the response and return the GPS coordinates to the client side.  Upon receipt of the response from the server, the client updates the state of the center of the map. This state change causes the application to re-render and make a request to the GET /yelp api to get the relevant restaurants.