### PR TITLE
Add delete account button in <Profile />

### DIFF
--- a/client/src/actions/__tests__/index.test.js
+++ b/client/src/actions/__tests__/index.test.js
@@ -3,8 +3,8 @@ import thunk from 'redux-thunk';
 
 import MockAdapter from 'axios-mock-adapter';
 import axios from 'axios';
-import { fetchUser, signup, signin, signout } from '../index';
-import { FETCH_USER, AUTH_USER, AUTH_UUID, SIGN_OUT } from '../types';
+import { fetchUser, signup, signin, signout, deleteUser } from '../index';
+import { FETCH_USER, AUTH_USER, AUTH_UUID, SIGN_OUT, DELETE_USER } from '../types';
 
 const middlewares = [thunk];
 const mockStore = configureStore(middlewares);
@@ -86,5 +86,19 @@ describe('async action creators', () => {
             const actions = store.getActions();
             expect(actions[0]).toEqual(expectedAction);
         })
-    })
+    });
+
+    it('should create an action to delete user', () => {
+        mock.onDelete("http://localhost:3090/users/me").reply(200);
+
+        const expectedAction =  {
+            type: DELETE_USER
+        };
+
+        const fakeToken = "this is a fake token";
+        return store.dispatch(deleteUser(fakeToken)).then(() => {
+            const actions = store.getActions();
+            expect(actions[0]).toEqual(expectedAction);
+        });
+    });
 });

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -70,12 +70,13 @@ export const fetchUser = (token) => async dispatch => {
 
 export const deleteUser = (token) => async dispatch => {
     try {
-        await axios.delete('http://localhost:3090/users/me', {}, {
+        await axios.delete('http://localhost:3090/users/me', {
             headers: {
                 "Authorization": `Bearer ${token}`
             }
         });
         dispatch({ type: DELETE_USER });
+        localStorage.removeItem('token');
     }
     catch(e) {
         console.log("There was an error in delete user!");

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT } from './types';
+import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT, DELETE_USER } from './types';
 
 export const signup = (email, password, callback) => async dispatch => {
     try {
@@ -66,4 +66,18 @@ export const fetchUser = (token) => async dispatch => {
     catch(e) {
         console.log("There was an error here");
     } 
+}
+
+export const deleteUser = (token) => async dispatch => {
+    try {
+        await axios.delete('http://localhost:3090/users/me', {}, {
+            headers: {
+                "Authorization": `Bearer ${token}`
+            }
+        });
+        dispatch({ type: DELETE_USER });
+    }
+    catch(e) {
+        console.log("There was an error in delete user!");
+    }
 }

--- a/client/src/actions/types.js
+++ b/client/src/actions/types.js
@@ -3,3 +3,4 @@ export const AUTH_ERROR = "auth_error";
 export const AUTH_UUID = "auth_uuid";
 export const FETCH_USER = "fetch_user";
 export const SIGN_OUT = "sign_out";
+export const DELETE_USER = "delete_user";

--- a/client/src/components/Profile.js
+++ b/client/src/components/Profile.js
@@ -24,6 +24,10 @@ class Profile extends Component {
         });
     }
 
+    deleteAccount = () => {
+        this.props.deleteUser(this.props.auth.authenticated);
+    }
+
     submitAvatar = async () => {
         const bodyFormData = new FormData();
         bodyFormData.append('avatar', this.state.pictures[0]);
@@ -60,7 +64,7 @@ class Profile extends Component {
     }
 
     render() {
-        console.log(this.state);
+        console.log(this.props);
         return(
             <div className="profile-wrapper">
                 <div className="profile-content-container">
@@ -82,6 +86,7 @@ class Profile extends Component {
                     <div className="profile-buttons">
                         <button onClick={() => this.submitAvatar()}>Save</button>
                         <button>Cancel</button>
+                        <button onClick={() => this.deleteAccount()}>Delete Account</button>
                         <Button className="profile-signout" text="Sign out" dest="/signout" />
                     </div>
                     {this.renderAvatar()}

--- a/client/src/reducers/__tests__/auth.test.js
+++ b/client/src/reducers/__tests__/auth.test.js
@@ -1,5 +1,5 @@
 import authReducer from '../auth';
-import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT } from '../../actions/types';
+import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT, DELETE_USER } from '../../actions/types';
 
 const INITIAL_STATE = {
     authenticated: '',
@@ -41,9 +41,16 @@ it('handles actions of type SIGN_OUT', () => {
     const action = { type: SIGN_OUT };
     const newState = authReducer(INITIAL_STATE, action);
     expect(newState).toEqual(emptyStateObject);
-})
+});
 
 it('handles actions of unknown type', () => {
     const newState = authReducer(INITIAL_STATE, { type: 'dfhsoiahfhwhewnfwionfw8' });
     expect(newState).toEqual(INITIAL_STATE);
+});
+
+it('handles the actions of type DELETE_USER', () => {
+    const emptyStateObject = {};
+    const action = { type: DELETE_USER };
+    const newState = authReducer(INITIAL_STATE, action);
+    expect(newState).toEqual(emptyStateObject);
 });

--- a/client/src/reducers/auth.js
+++ b/client/src/reducers/auth.js
@@ -1,4 +1,4 @@
-import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT } from '../actions/types';
+import { AUTH_USER, AUTH_ERROR, AUTH_UUID, FETCH_USER, SIGN_OUT, DELETE_USER } from '../actions/types';
 
 const INITIAL_STATE = {
     authenticated: '',
@@ -18,7 +18,9 @@ export default function (state = INITIAL_STATE, action) {
         case FETCH_USER:
             return { ...state, user: action.payload };
         case SIGN_OUT:
-             return {};
+            return {};
+        case DELETE_USER:
+            return {};
         default:
             return state;
     }

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -3,15 +3,9 @@ const { jwtSecret } = require('../config/keys');
 const User = require('../models/User');
 
 const auth = async (req, res, next) => {
-    console.log("1. Inside of the middleware");
-    console.log(req.body);
-    // console.log(req.body.header('Authorization'));
-    // console.log("This is the req object", req);
     try {
         const token = req.header('Authorization').replace('Bearer ', '');
-        console.log(token);
         const decoded = jwt.verify(token, jwtSecret);
-        console.log("DECODED", decoded);
         const user = await User.findOne({ _id: decoded._id, 'tokens.token': token });
 
         if(!user) {

--- a/server/router.js
+++ b/server/router.js
@@ -8,6 +8,16 @@ const auth = require('./middleware/auth');
 
 module.exports = function (app) {
 
+    app.delete('/users/me', auth, async (req, res) => {
+        console.log("Do I even get here inside of the route?");
+        try {
+            await req.user.remove();
+            res.send(req.user);
+        } catch(e) {
+            res.status(500).send();
+        }
+    });
+
     app.get('/forwardgeocode', async (req, res) => {
         console.log("This runs here line 10!");
         const { location, lat, lng } = req.query;
@@ -140,15 +150,6 @@ module.exports = function (app) {
             res.send(user.avatar);
         } catch(e) {
             res.status(404).send();
-        }
-    });
-
-    app.delete('/users/me', auth, async (req, res) => {
-        try {
-            await req.user.remove();
-            res.send({ message: "Success deleted user" });
-        } catch(e) {
-            res.status(400).send();
         }
     });
 }


### PR DESCRIPTION
A user can click a button to delete their own account. It makes a DELETE request to the server and removes the user document from the DB. The application state is then set to an empty object and the token is removed from local storage. The user is then redirected to the root route.